### PR TITLE
upgrade protoc and protoc-gen-grpc-java version

### DIFF
--- a/idl/build.gradle
+++ b/idl/build.gradle
@@ -32,14 +32,14 @@ dependencies {
 protobuf {
     protoc {
         // The artifact spec for the Protobuf Compiler
-        artifact = 'com.google.protobuf:protoc:3.6.1'
+        artifact = 'com.google.protobuf:protoc:3.18.0'
     }
     plugins {
         // Optional: an artifact spec for a protoc plugin, with "grpc" as
         // the identifier, which can be referred to in the "plugins"
         // container of the "generateProtoTasks" closure.
         grpc {
-            artifact = 'io.grpc:protoc-gen-grpc-java:1.15.1'
+            artifact = 'io.grpc:protoc-gen-grpc-java:1.50.0'
         }
     }
     generateProtoTasks {


### PR DESCRIPTION
With the current protoc and protoc-gen-grpc-java version, it cannot compile on Mac computers with Apple silicon (M1, M2, M3).
Compile Errors
```
Execution failed for task ':idl:generateProto'.
> Could not resolve all files for configuration ':idl:protobufToolsLocator_protoc'.
   > Could not find protoc-3.6.1-osx-aarch_64.exe (com.google.protobuf:protoc:3.6.1).
```
```
Execution failed for task ':idl:generateProto'.
> Could not resolve all files for configuration ':idl:protobufToolsLocator_grpc'.
   > Could not find protoc-gen-grpc-java-1.15.1-osx-aarch_64.exe (io.grpc:protoc-gen-grpc-java:1.15.1).
```
Both the above libraries cannot be found under
- https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.6.1/
- https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.15.1/

but can found in
- https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.18.0/
- https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.50.0/