### PR TITLE
Update rootProject name in settings.gradle

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'org.gradle.toolchains.foojay-resolver-convention' version '0.7.0'
 }
 
-rootProject.name = 'uforwarder'
+rootProject.name = 'uForwarder'
 include('fievel-common', 'instrumentation', 'idl', 'uforwarder-client', 'uforwarder-core', 'uforwarder', 'uforwarder-image', 'uforwarder-container', 'uforwarder-sample-consumer')
 
 dependencyResolutionManagement {


### PR DESCRIPTION
Without changing rootProject.name from uforwarder to uForwarder, when we import the project to IntelliJ, It could have the following errors
- java.lang.IllegalStateException: Module entity with name: uForwarder should be available
- cannot recognize classes in idl directory and Spring framework
- cannot automatically identity source and test files

After upgrading it, the above issues resolved. 

Another option is to change the code repository name to uforwarder instead of u**F**orwader